### PR TITLE
Update gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,35 @@
+# Dependencies
 node_modules/
-.env
 server/node_modules/
 client/node_modules/
+
+# Build outputs
+.dist/
+dist/
+build/
+.vite/
+.cache/
 coverage/
+
+# Package manager lockfiles we don't track
+pnpm-lock.yaml
+yarn.lock
+npm-debug.log*
+
+# Environment files
+.env
+.env.*
+
+# Media directories
+media/images/
+media/videos/
+
+# IDE/editor artifacts
+.vscode/
+.idea/
 .DS_Store
+Thumbs.db
+
+# Misc
+server/coverage/
+client/coverage/


### PR DESCRIPTION
## Summary
- expand the gitignore to cover build directories, caches, and media folders
- ensure environment files and package manager artifacts remain excluded from version control

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d65d83e75c8325948fb0dca7e65f8e